### PR TITLE
include batch() and chainable batch tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "idb-wrapper": "git://github.com/maxogden/IDBWrapper.git#autoContinueOption",
-    "abstract-leveldown": "~0.3.0",
+    "abstract-leveldown": "~0.7.1",
     "levelup": "git://github.com/rvagg/node-levelup.git#0.9-wip",
     "isbuffer": "0.0.0"
   }

--- a/test.js
+++ b/test.js
@@ -17,6 +17,8 @@ require('abstract-leveldown/abstract/put-test').all(factory, tape, testCommon)
 require('abstract-leveldown/abstract/del-test').all(factory, tape, testCommon)
 require('abstract-leveldown/abstract/get-test').all(factory, tape, testCommon)
 require('abstract-leveldown/abstract/put-get-del-test').all(factory, tape, testCommon, testBuffer)
+require('abstract-leveldown/abstract/batch-test').all(factory, tape, testCommon)
+require('abstract-leveldown/abstract/chained-batch-test').all(factory, tape, testCommon)
 require('abstract-leveldown/abstract/close-test').close(factory, tape, testCommon)
 require('abstract-leveldown/abstract/iterator-test').all(factory, tape, testCommon)
 


### PR DESCRIPTION
The batch() tests are ready for use in AbstractLevelDOWN so I've included them here. You have issues with `type:'del'` and `batch.del()` that need to be sorted out to get passes, but the rest is ready to roll and looking good--you get the new chained batch syntax free of charge! (e.g. `db.batch().put('foo', 'bar').del('bam').write(cb)`)
