### PR TITLE
Update dependencies for levelup

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "idb-wrapper": "git://github.com/maxogden/IDBWrapper.git#autoContinueOption",
     "abstract-leveldown": "~0.7.1",
-    "levelup": "git://github.com/rvagg/node-levelup.git#0.9-wip",
+    "levelup": "~0.9.0",
     "isbuffer": "0.0.0"
   }
 }


### PR DESCRIPTION
The levelup 0.9-wip branch is closed and 0.9.0 is released.

The same tests fail for me with either version of levelup installed. (113 165 191 192)
