### PR TITLE
Do not throw for approximateSize but pass err to callback instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,12 @@ Level.prototype._close = function (callback) {
   callback()
 }
 
-Level.prototype._approximateSize = function() {
-  throw new Error('Not implemented')
+Level.prototype._approximateSize = function (start, end, callback) {
+  var err = new Error('Not implemented')
+  if (callback)
+    return callback(err)
+
+  throw err
 }
 
 Level.prototype._isBuffer = isBuffer


### PR DESCRIPTION
As title ;).

In LevelGraph I need to feature-check approximateSize, and the current 'throw fast' approach collides with the deferred open support in LevelUp, so I cannot catch it.

Any other solution/workaround are ok for me.
