### PR TITLE
Avoid keyword in cursor.continue()

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -93,7 +93,7 @@ Iterator.prototype.onItem = function (value, cursor, cursorTransaction) {
     shouldCall = false
   
   if (shouldCall) this.callback(false, cursor.key, cursor.value)
-  if (cursor) cursor.continue()
+  if (cursor) cursor['continue']()
 }
 
 Iterator.prototype._next = function (callback) {


### PR DESCRIPTION
The method `continue` shouldn't be called in the bare format, because it's a keyword, so it'll throw an error on older browsers.  E.g. I get a SyntaxError on Android 2.1.
