### PR TITLE
Making tests pass in IE11

### DIFF
--- a/test/idb-shim.js
+++ b/test/idb-shim.js
@@ -1676,8 +1676,13 @@ module.exports = function() {
           if(!window.IDBTransaction){
               window.IDBTransaction = {};
           }
-          window.IDBTransaction.READ_ONLY = window.IDBTransaction.READ_ONLY || "readonly";
-          window.IDBTransaction.READ_WRITE = window.IDBTransaction.READ_WRITE || "readwrite";
+          if (!window.IDBTransaction.READ_ONLY) {
+            window.IDBTransaction.READ_ONLY = "readonly";
+          }
+          if (!window.IDBTransaction.READ_WRITE) {
+            window.IDBTransaction.READ_WRITE = "readwrite";
+          }
+          
       }
     
   }(window, idbModules));


### PR DESCRIPTION
IE11 was complaining that IDBTransaction.READ_ONLY and READ_WRITE couldn't be overwritten in strict mode.  _shrug_
