### PR TITLE
Force airtap's browserify to use buffer@5

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -14,3 +14,10 @@ browsers:
   - name: ie
     version: latest
     platform: Windows 10
+
+# Force browserify to use latest buffer@5.
+# Ideally we'd use latest browserify to achieve that,
+# but airtap currently depends on browserify@13.
+browserify:
+  - require: "buffer/"
+    expose: "buffer"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 * Remove testling from `package.json` (@vweevers)
 * Remove `level.js` logo (@vweevers)
 
-**Historical Note** As a result of removing `IDBWrapper`, only modern browsers with a non-prefixed `window.indexedDB` are supported in this release. IE10 and Firefox 52 are known to be broken. The current test matrix of `level-js` includes the latest versions of Chrome, Firefox, Safari, Edge and IE.
+**Historical Note** As a result of removing `IDBWrapper`, only modern browsers with a non-prefixed `window.indexedDB` are supported in this release. The current test matrix of `level-js` includes the latest versions of Chrome, Firefox, Safari, Edge and IE.
 
 **Historical Note** Though `level-js` now passes the full `abstract-leveldown` test suite, fulfulling the snapshot guarantee (reads not being affected by simultaneous writes) means a loss of backpressure as iterators have to keep reading from their IndexedDB cursors. Memory consumption might increase if an iterator is not consumed fast enough. A future release will have an option to favor backpressure over snapshot guarantees.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "airtap": "0.0.7",
-    "browserify": "~16.2.2",
+    "buffer": "~5.1.0",
     "encoding-down": "~5.0.2",
     "levelup": "~3.0.0",
     "pinkie": "~2.0.4",


### PR DESCRIPTION
Not the best solution but I want to trigger a Sauce Labs build. Closes #99.