### PR TITLE
Whitelist npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,14 @@
     "test": "standard && airtap --local --no-coverage test/index.js",
     "test-browsers": "standard && airtap --sauce-connect --loopback airtap.local --no-coverage test/index.js"
   },
+  "files": [
+    "index.js",
+    "iterator.js",
+    "util",
+    "collaborators.md",
+    "CHANGELOG.md",
+    "sauce-labs.svg"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:Level/level-js.git"


### PR DESCRIPTION
Closes #106.

After:

```
$ irish-pub
npm will publish level-js@3.0.0-rc1 as vweevers, including the following files:

package.json
README.md
index.js
iterator.js
collaborators.md
CHANGELOG.md
LICENSE.md
sauce-labs.svg
util/immediate-browser.js
util/immediate.js
util/is-data-clone-error.js
util/mixed-to-buffer.js
util/support.js
```