### PR TITLE
Support clear()

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -1,10 +1,8 @@
-/* global IDBKeyRange */
-
 'use strict'
 
 var inherits = require('inherits')
 var AbstractIterator = require('abstract-leveldown').AbstractIterator
-var ltgt = require('ltgt')
+var createKeyRange = require('./util/key-range')
 var deserialize = require('./util/deserialize')
 var setImmediate = require('./util/immediate')
 var noop = function () {}
@@ -34,7 +32,7 @@ function Iterator (db, location, options) {
   }
 
   try {
-    var keyRange = this.createKeyRange(options)
+    var keyRange = createKeyRange(options)
   } catch (e) {
     // The lower key is greater than the upper key.
     // IndexedDB throws an error, but we'll just return 0 results.
@@ -46,23 +44,6 @@ function Iterator (db, location, options) {
 }
 
 inherits(Iterator, AbstractIterator)
-
-Iterator.prototype.createKeyRange = function (options) {
-  var lower = ltgt.lowerBound(options)
-  var upper = ltgt.upperBound(options)
-  var lowerOpen = ltgt.lowerBoundExclusive(options)
-  var upperOpen = ltgt.upperBoundExclusive(options)
-
-  if (lower !== undefined && upper !== undefined) {
-    return IDBKeyRange.bound(lower, upper, lowerOpen, upperOpen)
-  } else if (lower !== undefined) {
-    return IDBKeyRange.lowerBound(lower, lowerOpen)
-  } else if (upper !== undefined) {
-    return IDBKeyRange.upperBound(upper, upperOpen)
-  } else {
-    return null
-  }
-}
 
 Iterator.prototype.createIterator = function (location, keyRange, reverse) {
   var self = this

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "./util/immediate.js": "./util/immediate-browser.js"
   },
   "dependencies": {
-    "abstract-leveldown": "~6.0.1",
+    "abstract-leveldown": "~6.1.1",
     "immediate": "~3.2.3",
     "inherits": "^2.0.3",
     "ltgt": "^2.1.2"

--- a/test/custom-test.js
+++ b/test/custom-test.js
@@ -296,5 +296,29 @@ module.exports = function (leveljs, test, testCommon) {
     })
   })
 
+  // TODO: move to abstract-leveldown test suite (and add to iterator tests too)
+  test('clear() with lower key greater than upper key', function (t) {
+    var db = testCommon.factory()
+
+    db.open(function (err) {
+      t.ifError(err, 'no open error')
+
+      db.put('a', 'a', function (err) {
+        t.ifError(err, 'no put error')
+
+        db.clear({ gt: 'b', lt: 'a' }, function (err) {
+          t.ifError(err, 'no clear error')
+
+          db.get('a', { asBuffer: false }, function (err, value) {
+            t.ifError(err, 'no get error')
+            t.is(value, 'a')
+
+            db.close(t.end.bind(t))
+          })
+        })
+      })
+    })
+  })
+
   test('teardown', testCommon.tearDown)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,10 @@ var testCommon = suite.common({
   seek: false,
 
   // Support of buffer keys depends on environment
-  bufferKeys: leveljs(uuid()).supports.bufferKeys
+  bufferKeys: leveljs(uuid()).supports.bufferKeys,
+
+  // Opt-in to new clear() tests
+  clear: true
 })
 
 // Test abstract-leveldown compliance

--- a/util/clear.js
+++ b/util/clear.js
@@ -1,0 +1,36 @@
+'use strict'
+
+var setImmediate = require('./immediate')
+
+module.exports = function clear (db, location, keyRange, options, callback) {
+  if (options.limit === 0) return setImmediate(callback)
+
+  var transaction = db.db.transaction([location], 'readwrite')
+  var store = transaction.objectStore(location)
+  var count = 0
+
+  transaction.oncomplete = function () {
+    callback()
+  }
+
+  transaction.onabort = function () {
+    callback(transaction.error || new Error('aborted by user'))
+  }
+
+  // A key cursor is faster (skips reading values) but not supported by IE
+  var method = store.openKeyCursor ? 'openKeyCursor' : 'openCursor'
+  var direction = options.reverse ? 'prev' : 'next'
+
+  store[method](keyRange, direction).onsuccess = function (ev) {
+    var cursor = ev.target.result
+
+    if (cursor) {
+      // Wait for a request to complete before continuing, saving CPU.
+      store.delete(cursor.key).onsuccess = function () {
+        if (options.limit <= 0 || ++count < options.limit) {
+          cursor.continue()
+        }
+      }
+    }
+  }
+}

--- a/util/key-range.js
+++ b/util/key-range.js
@@ -1,0 +1,23 @@
+/* global IDBKeyRange */
+
+'use strict'
+
+var ltgt = require('ltgt')
+var NONE = {}
+
+module.exports = function createKeyRange (options) {
+  var lower = ltgt.lowerBound(options, NONE)
+  var upper = ltgt.upperBound(options, NONE)
+  var lowerOpen = ltgt.lowerBoundExclusive(options, NONE)
+  var upperOpen = ltgt.upperBoundExclusive(options, NONE)
+
+  if (lower !== NONE && upper !== NONE) {
+    return IDBKeyRange.bound(lower, upper, lowerOpen, upperOpen)
+  } else if (lower !== NONE) {
+    return IDBKeyRange.lowerBound(lower, lowerOpen)
+  } else if (upper !== NONE) {
+    return IDBKeyRange.upperBound(upper, upperOpen)
+  } else {
+    return null
+  }
+}


### PR DESCRIPTION
Supersedes #175. Ref https://github.com/Level/community/issues/79.

The default `_clear()` of `abstract-leveldown` doesn't work here, because some environments lack binary key support.