### PR TITLE
fix: allow empty prefix option

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function Level (location, opts) {
   }
 
   this.location = location
-  this.prefix = opts.prefix || DEFAULT_PREFIX
+  this.prefix = opts.prefix === undefined ? DEFAULT_PREFIX : opts.prefix
   this.version = parseInt(opts.version || 1, 10)
 }
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function Level (location, opts) {
   }
 
   this.location = location
-  this.prefix = opts.prefix === undefined ? DEFAULT_PREFIX : opts.prefix
+  this.prefix = opts.prefix == null ? DEFAULT_PREFIX : opts.prefix
   this.version = parseInt(opts.version || 1, 10)
 }
 

--- a/test/custom-test.js
+++ b/test/custom-test.js
@@ -47,6 +47,27 @@ module.exports = function (leveljs, test, testCommon) {
     })
   })
 
+  test('empty prefix', function (t) {
+    var db = testCommon.factory({ prefix: '' })
+
+    t.ok(db.location, 'instance has location property')
+    t.is(db.prefix, '', 'instance has prefix property')
+
+    db.open(function (err) {
+      t.notOk(err, 'no open error')
+
+      var idb = db.db
+      var databaseName = idb.name
+      var storeNames = idb.objectStoreNames
+
+      t.is(databaseName, db.location, 'database name is prefixed')
+      t.is(storeNames.length, 1, 'created 1 object store')
+      t.is(storeNames.item(0), db.location, 'object store name equals location')
+
+      db.close(t.end.bind(t))
+    })
+  })
+
   test('put Buffer value, get Buffer value', function (t) {
     var level = testCommon.factory()
     level.open(function (err) {


### PR DESCRIPTION
This PR changes the default behaviour of the constructor to allow empty prefixes in databases - previously if you passed `''` as the prefix it would set it to `level-js-`.