### PR TITLE
Backport: restore support of empty prefix option

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function Level (location, opts) {
   }
 
   this.location = location
-  this.prefix = opts.prefix || DEFAULT_PREFIX
+  this.prefix = opts.prefix == null ? DEFAULT_PREFIX : opts.prefix
   this.version = parseInt(opts.version || 1, 10)
 }
 

--- a/test/custom-test.js
+++ b/test/custom-test.js
@@ -47,6 +47,27 @@ module.exports = function (leveljs, test, testCommon) {
     })
   })
 
+  test('empty prefix', function (t) {
+    var db = testCommon.factory({ prefix: '' })
+
+    t.ok(db.location, 'instance has location property')
+    t.is(db.prefix, '', 'instance has prefix property')
+
+    db.open(function (err) {
+      t.notOk(err, 'no open error')
+
+      var idb = db.db
+      var databaseName = idb.name
+      var storeNames = idb.objectStoreNames
+
+      t.is(databaseName, db.location, 'database name is prefixed')
+      t.is(storeNames.length, 1, 'created 1 object store')
+      t.is(storeNames.item(0), db.location, 'object store name equals location')
+
+      db.close(t.end.bind(t))
+    })
+  })
+
   test('put Buffer value, get Buffer value', function (t) {
     var level = testCommon.factory()
     level.open(function (err) {

--- a/test/structured-clone-test.js
+++ b/test/structured-clone-test.js
@@ -128,7 +128,9 @@ var types = [
 
 // Types that are not supported by the structured clone algorithm
 var illegalTypes = [
-  { name: 'Error', value: new Error() },
+  // Latest Chrome does seem to support Error, so skip this test.
+  // { name: 'Error', value: new Error() },
+
   { name: 'Function', value: function () {} },
   { name: 'DOMNode', value: global.document }
 ]


### PR DESCRIPTION
This restores a previous behavior (of `level-js` < 3) that unknown to us, was provided by the since-removed IDBWrapper.

Backport of https://github.com/Level/level-js/pull/184. cc @achingbrain 