### PR TITLE
fix: add buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "abstract-leveldown": "~6.2.1",
+    "buffer": "^5.5.0",
     "immediate": "~3.2.3",
     "inherits": "^2.0.3",
     "ltgt": "^2.1.2"

--- a/util/deserialize.js
+++ b/util/deserialize.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 var ta2str = (function () {
   if (global.TextDecoder) {
     var decoder = new TextDecoder('utf-8')

--- a/util/serialize.js
+++ b/util/serialize.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 // Returns either a Uint8Array or Buffer (doesn't matter to
 // IndexedDB, because Buffer is a subclass of Uint8Array)
 var str2bin = (function () {

--- a/util/support.js
+++ b/util/support.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 exports.test = function (key) {
   return function test (impl) {
     try {


### PR DESCRIPTION
This PR adds the `buffer` dependency, so we don't need to rely on bundlers outdated magic injections, webpack 5 will actually stop injecting node globals and electron renderer also has issues with undefined node globals depending on how the users compiles and runs the code.