### PR TITLE
chore: update buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "abstract-leveldown": "^6.3.0",
-    "buffer": "^5.5.0",
+    "buffer": "^6.0.3",
     "inherits": "^2.0.3",
     "ltgt": "^2.1.2"
   },


### PR DESCRIPTION
Updates `Buffer` to the latest version as having multiple versions in
the dep tree causes quite a lot of bundle bloat when run in browsers!

Refs: https://github.com/Level/abstract-leveldown/pull/373