### PR TITLE
Only run 1 GitHub Actions workflow at a time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Test
 on: push
+concurrency: sauce-labs
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise we'll hit Sauce Labs concurrency limits. Uses a [beta feature](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) that just [came out today](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/).

Ref Level/community#99